### PR TITLE
A-2: opt-in retry + backoff (429/5xx) in transport

### DIFF
--- a/packages/iapp-core/src/iapp_core/transport.py
+++ b/packages/iapp-core/src/iapp_core/transport.py
@@ -11,11 +11,17 @@ keep separate bodies because their file-handling contracts differ:
 """
 
 import os
+import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from .config import API_BASE, CONNECT_TIMEOUT, READ_TIMEOUT
 from .errors import IAppAPIError, status_error_message
 from .formatting import resolve_input_file
+
+
+def _is_retryable_status(status: int) -> bool:
+    """Transient statuses worth retrying: rate limiting and server errors."""
+    return status == 429 or 500 <= status < 600
 
 
 def request_sync(
@@ -30,6 +36,8 @@ def request_sync(
     files: Optional[Any] = None,
     raise_for_error: bool = False,
     timeout: Optional[float] = None,
+    retries: int = 0,
+    backoff_factor: float = 0.5,
 ):
     """Make an authenticated sync request and return the raw ``requests.Response``.
 
@@ -38,22 +46,35 @@ def request_sync(
     verbatim (callers pick their own field names and content types). The
     ``apikey`` header is injected first; any ``headers`` provided by the caller
     are merged on top (so a caller can add e.g. ``Content-Type``).
+
+    Retry/backoff is opt-in and off by default (``retries=0``), so existing
+    callers are unaffected. When ``retries`` > 0, transient responses (429 and
+    5xx) are retried up to ``retries`` extra times with exponential backoff
+    (``backoff_factor * 2**attempt`` seconds). Retries re-send the request as-is,
+    so use it for calls without an already-consumed file body.
     """
     import requests
 
     request_headers = {"apikey": apikey}
     if headers:
         request_headers.update(headers)
-    response = requests.request(
-        method,
-        url,
-        headers=request_headers,
-        params=params,
-        data=data,
-        json=json_body,
-        files=files,
-        timeout=timeout,
-    )
+    attempt = 0
+    while True:
+        response = requests.request(
+            method,
+            url,
+            headers=request_headers,
+            params=params,
+            data=data,
+            json=json_body,
+            files=files,
+            timeout=timeout,
+        )
+        if attempt < retries and _is_retryable_status(response.status_code):
+            time.sleep(backoff_factor * (2 ** attempt))
+            attempt += 1
+            continue
+        break
     if raise_for_error and response.status_code >= 400:
         raise IAppAPIError(status_error_message(response.status_code, response.text))
     return response

--- a/packages/iapp-core/tests/test_retry_backoff.py
+++ b/packages/iapp-core/tests/test_retry_backoff.py
@@ -1,0 +1,72 @@
+"""Unit tests for A-2: opt-in retry + backoff in request_sync.
+
+Retries are off by default (backward compatible) and, when enabled, fire on 429
+and 5xx with exponential backoff. ``time.sleep`` is patched so tests don't wait.
+"""
+
+import sys
+import types
+
+import pytest
+
+from iapp_core import transport
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Drive request_sync with a scripted sequence of status codes."""
+    state = {"statuses": [200], "calls": 0, "sleeps": []}
+
+    class _Resp:
+        def __init__(self, status):
+            self.status_code = status
+            self.text = ""
+
+    def fake_request(method, url, **kwargs):
+        i = min(state["calls"], len(state["statuses"]) - 1)
+        status = state["statuses"][i]
+        state["calls"] += 1
+        return _Resp(status)
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.request = fake_request
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setattr(transport.time, "sleep", lambda s: state["sleeps"].append(s))
+    return state
+
+
+def test_no_retry_by_default(fake_http):
+    fake_http["statuses"] = [429, 200]
+    resp = transport.request_sync("GET", "https://x.test", apikey="K")
+    assert resp.status_code == 429  # not retried
+    assert fake_http["calls"] == 1
+
+
+def test_retries_on_429_then_succeeds(fake_http):
+    fake_http["statuses"] = [429, 200]
+    resp = transport.request_sync("GET", "https://x.test", apikey="K", retries=3)
+    assert resp.status_code == 200
+    assert fake_http["calls"] == 2
+    assert fake_http["sleeps"] == [0.5]  # backoff_factor * 2**0
+
+
+def test_retries_on_5xx(fake_http):
+    fake_http["statuses"] = [503, 502, 200]
+    resp = transport.request_sync("GET", "https://x.test", apikey="K", retries=3)
+    assert resp.status_code == 200
+    assert fake_http["calls"] == 3
+    assert fake_http["sleeps"] == [0.5, 1.0]  # exponential
+
+
+def test_gives_up_after_retries_exhausted(fake_http):
+    fake_http["statuses"] = [429]  # always 429
+    resp = transport.request_sync("GET", "https://x.test", apikey="K", retries=2)
+    assert resp.status_code == 429
+    assert fake_http["calls"] == 3  # 1 initial + 2 retries
+
+
+def test_4xx_other_than_429_not_retried(fake_http):
+    fake_http["statuses"] = [403, 200]
+    resp = transport.request_sync("GET", "https://x.test", apikey="K", retries=3)
+    assert resp.status_code == 403
+    assert fake_http["calls"] == 1


### PR DESCRIPTION
เพิ่ม retry/backoff แบบ opt-in (default retries=0 → ของเดิมไม่เปลี่ยน)

- retry เฉพาะ 429 + 5xx, exponential backoff
- Tests: +5 (test_retry_backoff) จำลอง 429/5xx/exhausted

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว.

🤖 Generated with [Claude Code](https://claude.com/claude-code)