### PR TITLE
A-4: map 400/403/404/500 to actionable errors

### DIFF
--- a/packages/iapp-core/src/iapp_core/errors.py
+++ b/packages/iapp-core/src/iapp_core/errors.py
@@ -8,6 +8,11 @@ class IAppAPIError(Exception):
 def status_error_message(status: int, text: str) -> str:
     """Map an HTTP error status (and response body) to an actionable message."""
     snippet = text[:500]
+    if status == 400:
+        return (
+            "Error: Bad request (400). The request was malformed or a required parameter "
+            f"is missing/invalid. Details: {snippet}"
+        )
     if status == 401:
         return (
             "Error: Authentication failed (401). Check that IAPP_API_KEY is a valid "
@@ -18,8 +23,23 @@ def status_error_message(status: int, text: str) -> str:
             "Error: Insufficient credits (402). Top up iApp credits (IC) at https://iapp.co.th. "
             f"Details: {snippet}"
         )
+    if status == 403:
+        return (
+            "Error: Access forbidden (403). Your API key is valid but not allowed to use "
+            f"this endpoint — check your plan or permissions at https://iapp.co.th. Details: {snippet}"
+        )
+    if status == 404:
+        return (
+            "Error: Not found (404). The endpoint or resource does not exist — check the "
+            f"URL/path for this service. Details: {snippet}"
+        )
     if status == 413:
         return "Error: File too large (413). Check the size limit for this service and resize/compress the file."
     if status == 429:
         return "Error: Rate limit exceeded (429). Wait a moment before retrying."
+    if status == 500:
+        return (
+            "Error: iApp server error (500). The service failed to process the request — "
+            f"retry shortly; if it persists, contact iApp support. Details: {snippet}"
+        )
     return f"Error: iApp API request failed with status {status}. Details: {snippet}"

--- a/packages/iapp-core/tests/test_error_mapping.py
+++ b/packages/iapp-core/tests/test_error_mapping.py
@@ -1,0 +1,37 @@
+"""Unit tests for A-4: HTTP status -> actionable message mapping.
+
+Confirms the main statuses (400/401/402/403/404/413/429/500) each get a
+specific message, and anything else falls back to the generic one.
+"""
+
+import pytest
+
+from iapp_core.errors import status_error_message
+
+MAPPED = [400, 401, 402, 403, 404, 413, 429, 500]
+
+
+@pytest.mark.parametrize("status", MAPPED)
+def test_mapped_status_mentions_its_code(status):
+    msg = status_error_message(status, "body")
+    assert str(status) in msg
+    assert msg.startswith("Error:")
+
+
+def test_400_403_404_500_were_added():
+    for status in (400, 403, 404, 500):
+        msg = status_error_message(status, "detail-text")
+        # Specific (not the generic "request failed with status N") message.
+        assert "request failed with status" not in msg
+
+
+def test_body_snippet_included_and_truncated():
+    long_body = "x" * 1000
+    msg = status_error_message(500, long_body)
+    assert "x" * 500 in msg
+    assert "x" * 501 not in msg
+
+
+def test_unmapped_status_uses_generic_message():
+    msg = status_error_message(418, "teapot")
+    assert "request failed with status 418" in msg


### PR DESCRIPTION
เพิ่ม mapping 400/403/404/500 ใน errors.py (เดิมมี 401/402/413/429)

- Tests: +6 (รวม parametrized 8 status)

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว.

🤖 Generated with [Claude Code](https://claude.com/claude-code)