### PR TITLE
A-5: GitHub Actions CI (ruff + mypy + pytest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-type-test:
+    name: lint + type + test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync workspace (all packages + extras + dev tools)
+        run: uv sync --all-packages --all-extras
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      # Ruff runs over the whole repo on its default rule set.
+      - name: Lint (ruff)
+        run: uv run ruff check packages
+
+      # Mypy gate is scoped to core + sdk, which are type-clean today. The MCP
+      # domain tools gain type hints under C-5 / D-7; add them here once green.
+      - name: Type check (mypy)
+        run: uv run mypy packages/iapp-core/src packages/iapp-sdk/src
+
+      - name: Test (pytest)
+        run: uv run pytest packages/iapp-core/tests packages/iapp-sdk/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy packages/iapp-core/src packages/iapp-sdk/src
 
+      # Discover tests under packages/ so this works on any branch — the per-task
+      # branches don't all carry packages/iapp-core/tests, but it exists once the
+      # feature branches merge to main.
       - name: Test (pytest)
-        run: uv run pytest packages/iapp-core/tests packages/iapp-sdk/tests
+        run: uv run pytest packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,22 @@
 
 [tool.uv.workspace]
 members = ["packages/iapp-core", "packages/iapp-sdk", "packages/iapp-mcp"]
+
+# Dev tooling for the CI pipeline (A-5). Installed by `uv sync`.
+[dependency-groups]
+dev = [
+    "ruff>=0.6,<1.0",
+    "mypy>=1.10,<3.0",
+    "pytest>=8,<10",
+]
+
+# Ruff stays on its default rule set (E4/E7/E9/F) so the existing code passes;
+# the team can opt into E501/import-sorting once domain files are reformatted.
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+# Third-party libs (httpx, mcp, pydantic, requests) ship without stubs here.
+ignore_missing_imports = true


### PR DESCRIPTION
CI ทุก push/PR บน py3.10–3.12 ผ่าน uv

- ruff ทั้ง repo, mypy core+sdk, pytest core+sdk
- เพิ่ม py.typed ให้ iapp-core + ruff/mypy config

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว.

🤖 Generated with [Claude Code](https://claude.com/claude-code)