### PR TITLE
A-7: central build_output_path() API (enables D-09)

### DIFF
--- a/packages/iapp-core/src/iapp_core/__init__.py
+++ b/packages/iapp-core/src/iapp_core/__init__.py
@@ -10,6 +10,8 @@ __version__ = "0.1.0"
 from .config import API_BASE, CONNECT_TIMEOUT, READ_TIMEOUT
 from .errors import IAppAPIError, status_error_message
 from .formatting import (
+    build_output_path,
+    default_output_dir,
     format_json_response,
     get_api_key,
     resolve_input_file,
@@ -26,6 +28,8 @@ __all__ = [
     "READ_TIMEOUT",
     "IAppAPIError",
     "status_error_message",
+    "build_output_path",
+    "default_output_dir",
     "format_json_response",
     "get_api_key",
     "resolve_input_file",

--- a/packages/iapp-core/src/iapp_core/formatting.py
+++ b/packages/iapp-core/src/iapp_core/formatting.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 import wave
-from typing import Any
+from typing import Any, Optional
 
 from .errors import IAppAPIError
 
@@ -45,6 +45,32 @@ def resolve_output_path(output_path: str) -> str:
     path = os.path.abspath(os.path.expanduser(output_path))
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     return path
+
+
+def default_output_dir() -> str:
+    """Base directory for generated output files.
+
+    Honors the ``IAPP_OUTPUT_DIR`` environment variable; falls back to ``media``
+    to preserve the legacy on-disk layout when nothing is configured.
+    """
+    return os.environ.get("IAPP_OUTPUT_DIR", "").strip() or "media"
+
+
+def build_output_path(filename: str, output_path: Optional[str] = None) -> str:
+    """Resolve where to save a generated file, creating the directory.
+
+    Central output-path API for domain methods that currently hardcode
+    ``media/...`` (defect D-09):
+
+    * ``output_path`` given  -> use it verbatim (caller is in full control),
+    * ``output_path`` omitted -> ``default_output_dir()/filename``.
+
+    The default stays ``media/`` so behavior is unchanged out of the box, but
+    callers (and ops, via ``IAPP_OUTPUT_DIR``) can now redirect output instead
+    of being locked to a hardcoded folder.
+    """
+    target = output_path if output_path else os.path.join(default_output_dir(), filename)
+    return resolve_output_path(target)
 
 
 def truncate_blobs(value: Any) -> Any:

--- a/packages/iapp-core/tests/test_output_path.py
+++ b/packages/iapp-core/tests/test_output_path.py
@@ -1,0 +1,48 @@
+"""Unit tests for A-7: central output-path API (defect D-09).
+
+Domain methods currently hardcode ``media/...``. build_output_path() gives them
+a single API: caller path wins, otherwise default to default_output_dir() which
+is ``media`` unless IAPP_OUTPUT_DIR overrides it.
+"""
+
+import os
+
+import pytest
+
+from iapp_core import build_output_path, default_output_dir
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("IAPP_OUTPUT_DIR", raising=False)
+
+
+def test_default_dir_is_media_without_env():
+    assert default_output_dir() == "media"
+
+
+def test_default_dir_honors_env(monkeypatch):
+    monkeypatch.setenv("IAPP_OUTPUT_DIR", "/tmp/iapp-out")
+    assert default_output_dir() == "/tmp/iapp-out"
+
+
+def test_explicit_output_path_wins(tmp_path):
+    target = tmp_path / "sub" / "voice.wav"
+    result = build_output_path("ignored.wav", str(target))
+    assert result == os.path.abspath(str(target))
+    assert os.path.isdir(os.path.dirname(result))  # parent dir created
+
+
+def test_default_falls_back_to_media_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    result = build_output_path("result.png")
+    assert result == os.path.join(str(tmp_path), "media", "result.png")
+    assert os.path.isdir(os.path.join(str(tmp_path), "media"))
+
+
+def test_env_dir_used_when_no_explicit_path(monkeypatch, tmp_path):
+    out = tmp_path / "generated"
+    monkeypatch.setenv("IAPP_OUTPUT_DIR", str(out))
+    result = build_output_path("a.png")
+    assert result == os.path.join(str(out), "a.png")
+    assert os.path.isdir(str(out))


### PR DESCRIPTION
API กลางแทน media/ hardcode (D-09): build_output_path()/default_output_dir(), IAPP_OUTPUT_DIR override. Tests: +5

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว.

🤖 Generated with [Claude Code](https://claude.com/claude-code)