### PR TITLE
A-1: default request_sync timeout to config (fixes D-13)

### DIFF
--- a/packages/iapp-core/src/iapp_core/transport.py
+++ b/packages/iapp-core/src/iapp_core/transport.py
@@ -11,7 +11,7 @@ keep separate bodies because their file-handling contracts differ:
 """
 
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .config import API_BASE, CONNECT_TIMEOUT, READ_TIMEOUT
 from .errors import IAppAPIError, status_error_message
@@ -29,7 +29,7 @@ def request_sync(
     json_body: Optional[Any] = None,
     files: Optional[Any] = None,
     raise_for_error: bool = False,
-    timeout: Optional[float] = None,
+    timeout: Optional[Union[float, Tuple[float, float]]] = None,
 ):
     """Make an authenticated sync request and return the raw ``requests.Response``.
 
@@ -38,9 +38,15 @@ def request_sync(
     verbatim (callers pick their own field names and content types). The
     ``apikey`` header is injected first; any ``headers`` provided by the caller
     are merged on top (so a caller can add e.g. ``Content-Type``).
+
+    ``timeout`` defaults to ``(CONNECT_TIMEOUT, READ_TIMEOUT)`` from
+    :mod:`iapp_core.config` so a stalled connection can never hang forever;
+    callers may pass their own float or ``(connect, read)`` tuple to override.
     """
     import requests
 
+    if timeout is None:
+        timeout = (CONNECT_TIMEOUT, READ_TIMEOUT)
     request_headers = {"apikey": apikey}
     if headers:
         request_headers.update(headers)

--- a/packages/iapp-core/tests/test_transport_timeout.py
+++ b/packages/iapp-core/tests/test_transport_timeout.py
@@ -1,0 +1,50 @@
+"""Unit tests for the sync transport timeout default (defect D-13).
+
+``request_sync`` must always send a timeout to ``requests`` so a stalled
+connection cannot hang the caller forever. By default it uses the
+``(CONNECT_TIMEOUT, READ_TIMEOUT)`` pair from :mod:`iapp_core.config`; an
+explicit ``timeout`` argument still overrides it.
+"""
+
+import sys
+import types
+
+import pytest
+
+from iapp_core import transport
+from iapp_core.config import CONNECT_TIMEOUT, READ_TIMEOUT
+
+
+@pytest.fixture
+def captured_requests(monkeypatch):
+    """Replace the ``requests`` module with a recorder for request_sync."""
+    calls = {}
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+    def fake_request(method, url, **kwargs):
+        calls.clear()
+        calls.update(method=method, url=url, **kwargs)
+        return _Resp()
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.request = fake_request
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    return calls
+
+
+def test_default_timeout_is_config_tuple(captured_requests):
+    transport.request_sync("GET", "https://example.com", apikey="K")
+    assert captured_requests["timeout"] == (CONNECT_TIMEOUT, READ_TIMEOUT)
+
+
+def test_explicit_timeout_overrides_default(captured_requests):
+    transport.request_sync("GET", "https://example.com", apikey="K", timeout=5.0)
+    assert captured_requests["timeout"] == 5.0
+
+
+def test_timeout_is_never_none(captured_requests):
+    transport.request_sync("POST", "https://example.com", apikey="K")
+    assert captured_requests["timeout"] is not None


### PR DESCRIPTION
แก้ D-13: request_sync ส่ง timeout=None -> request ค้างได้. ใส่ default (CONNECT_TIMEOUT, READ_TIMEOUT) จาก config. Tests: +3

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว. base=develop ตามรีวิวของ @warisara29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)