### PR TITLE
A-3: central build_url() + open_input_files() (enables D-01, D-05)

### DIFF
--- a/packages/iapp-core/src/iapp_core/__init__.py
+++ b/packages/iapp-core/src/iapp_core/__init__.py
@@ -12,6 +12,7 @@ from .errors import IAppAPIError, status_error_message
 from .formatting import (
     format_json_response,
     get_api_key,
+    open_input_files,
     resolve_input_file,
     resolve_output_path,
     save_binary,
@@ -19,6 +20,7 @@ from .formatting import (
     truncate_blobs,
 )
 from .transport import request_async, request_sync
+from .urls import build_url
 
 __all__ = [
     "API_BASE",
@@ -26,8 +28,10 @@ __all__ = [
     "READ_TIMEOUT",
     "IAppAPIError",
     "status_error_message",
+    "build_url",
     "format_json_response",
     "get_api_key",
+    "open_input_files",
     "resolve_input_file",
     "resolve_output_path",
     "save_binary",

--- a/packages/iapp-core/src/iapp_core/formatting.py
+++ b/packages/iapp-core/src/iapp_core/formatting.py
@@ -9,7 +9,8 @@ import json
 import os
 import re
 import wave
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Iterator, List
 
 from .errors import IAppAPIError
 
@@ -45,6 +46,29 @@ def resolve_output_path(output_path: str) -> str:
     path = os.path.abspath(os.path.expanduser(output_path))
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     return path
+
+
+@contextmanager
+def open_input_files(file_paths: List[str], mode: str = "rb") -> Iterator[List]:
+    """Open several input files and guarantee every handle is closed.
+
+    Many SDK methods open files for multipart upload but never close them, so
+    handles leak (defect D-01). Wrap the open/use in this context manager and
+    every handle is closed on exit — even if the request raises::
+
+        with open_input_files([img1, img2]) as (fh1, fh2):
+            request_sync(..., files=[("file1", (name1, fh1)), ...])
+
+    Each path is validated through :func:`resolve_input_file` first.
+    """
+    handles: List = []
+    try:
+        for file_path in file_paths:
+            handles.append(open(resolve_input_file(file_path), mode))
+        yield handles
+    finally:
+        for handle in handles:
+            handle.close()
 
 
 def truncate_blobs(value: Any) -> Any:

--- a/packages/iapp-core/src/iapp_core/urls.py
+++ b/packages/iapp-core/src/iapp_core/urls.py
@@ -1,0 +1,31 @@
+"""URL-building helpers for iApp AI Marketplace clients.
+
+Several SDK methods build request URLs by concatenating Thai text straight into
+a query string (``...?text=สวัสดี``). Un-encoded non-ASCII produces invalid URLs
+that fail or get mangled in transit. :func:`build_url` percent-encodes every
+query value so domain methods can stop hand-building URLs (fixes D-05).
+"""
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+
+def build_url(base: str, path: str = "", params: Optional[Dict[str, Any]] = None) -> str:
+    """Join ``base`` and ``path`` and append a URL-encoded query string.
+
+    ``params`` values are percent-encoded (so Thai text and other non-ASCII are
+    safe). ``None`` values are dropped. Exactly one ``/`` is placed between
+    ``base`` and ``path``. This helper never injects auth — callers decide
+    whether an apikey belongs in the query or a header.
+
+    >>> build_url("https://api.iapp.co.th", "translate/auto", {"text": "สวัสดี"})
+    'https://api.iapp.co.th/translate/auto?text=%E0%B8%AA%E0%B8%A7%E0%B8%B1%E0%B8%94%E0%B8%94%E0%B8%B5'
+    """
+    url = base.rstrip("/")
+    if path:
+        url = f"{url}/{path.lstrip('/')}"
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url = f"{url}?{urlencode(clean, doseq=True)}"
+    return url

--- a/packages/iapp-core/tests/test_url_file_helpers.py
+++ b/packages/iapp-core/tests/test_url_file_helpers.py
@@ -1,0 +1,73 @@
+"""Unit tests for the A-3 central helpers: build_url + open_input_files.
+
+These back defect fixes D-05 (un-encoded Thai in URLs) and D-01 (leaked file
+handles). The helpers are generic; domain methods wire them in separately.
+"""
+
+import warnings
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from iapp_core import build_url, open_input_files
+
+
+def test_build_url_joins_base_and_path():
+    assert build_url("https://api.iapp.co.th", "translate/auto") == (
+        "https://api.iapp.co.th/translate/auto"
+    )
+
+
+def test_build_url_single_slash_between_segments():
+    # Trailing/leading slashes collapse to exactly one.
+    assert build_url("https://api.iapp.co.th/", "/asr") == "https://api.iapp.co.th/asr"
+
+
+def test_build_url_percent_encodes_thai():
+    url = build_url("https://api.iapp.co.th", "translate/auto", {"text": "สวัสดี"})
+    parsed = urlparse(url)
+    # Raw Thai must not appear unencoded in the query string...
+    assert "สวัสดี" not in url
+    # ...but must round-trip back to the original value.
+    assert parse_qs(parsed.query)["text"] == ["สวัสดี"]
+
+
+def test_build_url_drops_none_params():
+    url = build_url("https://x.test", "p", {"a": "1", "b": None})
+    assert url == "https://x.test/p?a=1"
+
+
+def test_build_url_no_query_when_params_empty():
+    assert build_url("https://x.test", "p", {}) == "https://x.test/p"
+
+
+def test_open_input_files_yields_open_handles_and_closes(tmp_path):
+    f1 = tmp_path / "a.bin"
+    f1.write_bytes(b"a")
+    f2 = tmp_path / "b.bin"
+    f2.write_bytes(b"b")
+    with open_input_files([str(f1), str(f2)]) as handles:
+        assert len(handles) == 2
+        assert all(not h.closed for h in handles)
+        captured = handles
+    assert all(h.closed for h in captured)  # closed on normal exit
+
+
+def test_open_input_files_closes_on_exception(tmp_path):
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"a")
+    captured = []
+    with pytest.raises(RuntimeError):
+        with open_input_files([str(f)]) as handles:
+            captured = handles
+            raise RuntimeError("boom")
+    assert captured and captured[0].closed  # closed even when body raises
+
+
+def test_open_input_files_no_resource_warning(tmp_path, recwarn):
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"a")
+    warnings.simplefilter("always")
+    with open_input_files([str(f)]):
+        pass
+    assert not [w for w in recwarn.list if issubclass(w.category, ResourceWarning)]


### PR DESCRIPTION
helper กลาง decoupled: build_url() (urlencode, D-05) + open_input_files() (ปิด handle, D-01). Tests: +8

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว. base=develop ตามรีวิวของ @warisara29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)