### PR TITLE
A-6: release automation — one-command build + version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+# Tag a release as v<version> (e.g. v1.4.0) to build all three packages in
+# dependency order and publish them to PyPI via trusted publishing (OIDC).
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Build core -> sdk -> mcp (one command)
+        run: uv run --with build python scripts/release.py build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # trusted publishing to PyPI
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Release automation for the iApp AI monorepo (task A-6).
+
+Subcommands::
+
+    python scripts/release.py build
+        Build all three packages in dependency order (core -> sdk -> mcp) into
+        ./dist with a single command. core is built first because the sdk and
+        mcp depend on it.
+
+    python scripts/release.py bump <core|sdk|mcp> <version>
+        Set one package's version in its pyproject.toml and keep its
+        __init__ __version__ in sync.
+
+Build uses ``python -m build`` (PEP 517), so no extra tooling is required; the
+GitHub Actions release workflow calls the same entry point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DIST = ROOT / "dist"
+
+# name -> (package dir, module __init__ that carries __version__)
+PACKAGES = {
+    "core": ("packages/iapp-core", "packages/iapp-core/src/iapp_core/__init__.py"),
+    "sdk": ("packages/iapp-sdk", "packages/iapp-sdk/src/iapp_ai/__init__.py"),
+    "mcp": ("packages/iapp-mcp", "packages/iapp-mcp/src/iapp_mcp/__init__.py"),
+}
+# core first: sdk and mcp depend on it.
+BUILD_ORDER = ["core", "sdk", "mcp"]
+
+_VERSION_RE = re.compile(r'^version\s*=\s*"[^"]*"', re.MULTILINE)
+_DUNDER_RE = re.compile(r'^__version__\s*=\s*"[^"]*"', re.MULTILINE)
+
+
+def set_project_version(pyproject_text: str, version: str) -> str:
+    """Return ``pyproject_text`` with the first ``version = "..."`` set to ``version``."""
+    new_text, n = _VERSION_RE.subn(f'version = "{version}"', pyproject_text, count=1)
+    if n != 1:
+        raise ValueError("no `version = \"...\"` line found in pyproject.toml")
+    return new_text
+
+
+def set_dunder_version(init_text: str, version: str) -> str:
+    """Return ``init_text`` with ``__version__ = "..."`` set to ``version`` (if present)."""
+    new_text, _ = _DUNDER_RE.subn(f'__version__ = "{version}"', init_text, count=1)
+    return new_text
+
+
+def bump(pkg: str, version: str) -> None:
+    if pkg not in PACKAGES:
+        raise SystemExit(f"unknown package {pkg!r}; choose from {', '.join(PACKAGES)}")
+    pkg_dir, init_rel = PACKAGES[pkg]
+    pyproject = ROOT / pkg_dir / "pyproject.toml"
+    pyproject.write_text(set_project_version(pyproject.read_text(), version))
+    init_path = ROOT / init_rel
+    if init_path.exists():
+        init_path.write_text(set_dunder_version(init_path.read_text(), version))
+    print(f"bumped {pkg} -> {version}")
+
+
+def build() -> None:
+    DIST.mkdir(exist_ok=True)
+    for pkg in BUILD_ORDER:
+        pkg_dir = ROOT / PACKAGES[pkg][0]
+        print(f"== building {pkg} ({pkg_dir.name}) ==")
+        subprocess.run(
+            [sys.executable, "-m", "build", "--outdir", str(DIST), str(pkg_dir)],
+            check=True,
+        )
+    print(f"built {len(BUILD_ORDER)} packages into {DIST}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="iApp AI monorepo release helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("build", help="build core -> sdk -> mcp into ./dist")
+    bump_p = sub.add_parser("bump", help="set a package version")
+    bump_p.add_argument("package", choices=list(PACKAGES))
+    bump_p.add_argument("version")
+    args = parser.parse_args(argv)
+    if args.cmd == "build":
+        build()
+    elif args.cmd == "bump":
+        bump(args.package, args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1,0 +1,41 @@
+"""Unit tests for the A-6 release helper version-bump logic."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import release  # noqa: E402
+
+
+def test_set_project_version_replaces_first_only():
+    text = 'name = "x"\nversion = "1.2.3"\n[other]\nversion = "9.9.9"\n'
+    out = release.set_project_version(text, "1.3.0")
+    assert 'version = "1.3.0"' in out
+    assert 'version = "9.9.9"' in out  # second untouched
+    assert '"1.2.3"' not in out
+
+
+def test_set_project_version_tolerates_spacing():
+    assert release.set_project_version('version="0.1.0"', "0.2.0") == 'version = "0.2.0"'
+
+
+def test_set_project_version_errors_when_absent():
+    with pytest.raises(ValueError):
+        release.set_project_version('name = "x"\n', "1.0.0")
+
+
+def test_set_dunder_version():
+    assert release.set_dunder_version('__version__ = "2.0.0"\n', "2.1.0") == '__version__ = "2.1.0"\n'
+
+
+def test_set_dunder_version_noop_when_absent():
+    text = "x = 1\n"
+    assert release.set_dunder_version(text, "2.1.0") == text
+
+
+def test_build_order_is_core_first():
+    assert release.BUILD_ORDER[0] == "core"
+    assert set(release.BUILD_ORDER) == set(release.PACKAGES)


### PR DESCRIPTION
scripts/release.py: build core->sdk->mcp คำสั่งเดียว + bump; release.yml tag v* -> publish. twine ผ่าน 6/6

— scope: core/platform only (ไม่แตะ module_api.py / mcp/tools). Backward-compat: SDK compat tests เขียว. base=develop ตามรีวิวของ @warisara29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)