### PR TITLE
Align NLP/Speech SDK endpoints with the live iApp API + smart-city test coverage

### DIFF
--- a/packages/iapp-sdk/src/iapp_ai/module_api.py
+++ b/packages/iapp-sdk/src/iapp_ai/module_api.py
@@ -489,14 +489,20 @@ class api():
     #     return response
 
     def power_meter(self, headers: Optional[Dict[str, Any]] = None, image: str = "") -> requests.Response:
+        """Read the number from a power/water meter image (base64 variant).
+
+        Endpoint: ``POST /v3/store/smart-city/power-meter-and-water-meter/base64``
+        with the image base64-encoded in a JSON body ``{"image": ...}``.
+        """
         headers = headers or {}
         with open_input_files([image]) as (image_file,):
             data = base64.b64encode(image_file.read()).decode("ascii")
         request_data_payload = json.dumps({
             'image': data})
 
-        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/file",
-                            apikey=self.apikey, headers=headers,
+        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/base64",
+                            apikey=self.apikey,
+                            headers={'Content-Type': 'application/json', **headers},
                             data=request_data_payload)
 
 

--- a/packages/iapp-sdk/src/iapp_ai/module_api.py
+++ b/packages/iapp-sdk/src/iapp_ai/module_api.py
@@ -50,6 +50,11 @@ class api():
                             data=request_data_payload)
 
     def thai_qgen_api(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Generate question-answer pairs from a Thai text passage.
+
+        Endpoint: ``GET /v3/store/nlp/question/generation`` with the source text
+        sent as the ``text`` query parameter.
+        """
         headers = headers or {}
         data_payload = data_payload or {}
         url = build_url(API_BASE, "v3/store/nlp/question/generation", {"text": str(text)})
@@ -57,22 +62,63 @@ class api():
         return request_sync("GET", url, apikey=self.apikey, headers=headers,
                             data={**data_payload})
 
-    def thai_text_summarization(self, text: str = "", output_length: Any = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+    def thai_text_summarization(self, text: str = "", style: Optional[str] = None, language: Optional[str] = None, max_output_tokens: Optional[int] = None, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Summarize a Thai or English text passage.
+
+        Endpoint: ``POST /v3/store/nlp/thai-text-summary`` with a JSON body.
+
+        Args:
+            text: The text to summarize (required).
+            style: Summary style — ``standard``, ``clarify`` or ``friendly``.
+            language: Output language — ``th`` or ``en``.
+            max_output_tokens: Optional cap on the length of the summary.
+            headers: Additional HTTP headers to send with the request.
+            data_payload: Extra JSON fields merged into the request body.
+        """
         headers = headers or {}
         data_payload = data_payload or {}
-        url = build_url(API_BASE, "v3/store/nlp/thai-text-summary",
-                        {"text": str(text), "output_length": str(output_length)})
+        body: Dict[str, Any] = {"text": str(text)}
+        if style is not None:
+            body["style"] = style
+        if language is not None:
+            body["language"] = language
+        if max_output_tokens is not None:
+            body["max_output_tokens"] = max_output_tokens
+        body.update(data_payload)
 
-        return request_sync("POST", url, apikey=self.apikey, headers=headers,
-                            data={**data_payload})
+        return request_sync("POST", f"{API_BASE}/v3/store/nlp/thai-text-summary",
+                            apikey=self.apikey,
+                            headers={'Content-Type': 'application/json', **headers},
+                            json_body=body)
 
-    def eng_thai_translate(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+    def eng_thai_translate(self, text: str = "", source_lang: str = "en", target_lang: str = "th", max_length: Optional[int] = None, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Translate text between supported languages (Thai-optimized).
+
+        Endpoint: ``POST /v3/store/nlp/multilingual-translation`` with a JSON body.
+
+        Args:
+            text: The text to translate (required).
+            source_lang: Source language code (defaults to ``en``).
+            target_lang: Target language code (defaults to ``th``).
+            max_length: Optional cap on the number of output tokens.
+            headers: Additional HTTP headers to send with the request.
+            data_payload: Extra JSON fields merged into the request body.
+        """
         headers = headers or {}
         data_payload = data_payload or {}
-        url = build_url(API_BASE, "v1/text/translate", {"text": text})
+        body: Dict[str, Any] = {
+            "text": text,
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+        }
+        if max_length is not None:
+            body["max_length"] = max_length
+        body.update(data_payload)
 
-        return request_sync("POST", url, apikey=self.apikey, headers=headers,
-                            data={**data_payload})
+        return request_sync("POST", f"{API_BASE}/v3/store/nlp/multilingual-translation",
+                            apikey=self.apikey,
+                            headers={'Content-Type': 'application/json', **headers},
+                            json_body=body)
 
 
 
@@ -1100,6 +1146,13 @@ class api():
     ################## Voice and Speech ##################
 
     def thai_asr_api(self, file_path: str, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, files: Optional[List[Any]] = None) -> requests.Response:
+        """Transcribe a Thai audio file to text.
+
+        Endpoint: ``POST /v3/store/speech/speech-to-text/base``, sent as
+        multipart form-data with the audio under the ``file`` field. Optional
+        form fields (e.g. ``chunk_size``, ``use_asr_pro``) may be supplied via
+        ``data_payload``.
+        """
         headers = headers or {}
         data_payload = data_payload or {}
         files = files or []
@@ -1107,29 +1160,45 @@ class api():
             request_files = [('file',(file_path, file_obj, 'audio/mpga'))]
             request_files.extend(files)
 
-            return request_sync("POST", "https://api.iapp.co.th/asr",
+            return request_sync("POST", f"{API_BASE}/v3/store/speech/speech-to-text/base",
                                 apikey=self.apikey, headers=headers,
                                 data={**data_payload}, files=request_files)
 
     def thai_thaitts_kaitom(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, output_path: Optional[str] = None) -> requests.Response:
+        """Synthesize Thai speech and save the audio to a local file.
+
+        Endpoint: ``POST /v3/store/audio/tts`` with a JSON body ``{"text": ...}``.
+        The response audio is written to ``output_path`` (defaults to
+        ``kaitom.wav`` in the output directory).
+        """
         headers = headers or {}
         data_payload = data_payload or {}
-        request_url = build_url(API_BASE, "v3/store/speech/text-to-speech/kaitom", {"text": text})
+        body = {"text": text, **data_payload}
 
-        response = request_sync("POST", request_url, apikey=self.apikey, headers=headers,
-                                data={**data_payload})
+        response = request_sync("POST", f"{API_BASE}/v3/store/audio/tts",
+                                apikey=self.apikey,
+                                headers={'Content-Type': 'application/json', **headers},
+                                json_body=body)
         path = build_output_path("kaitom.wav", output_path)
         with open(path, "wb") as file:
             file.write(response.content)
         return response
 
     def thai_thaitts_cee(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, output_path: Optional[str] = None) -> requests.Response:
+        """Synthesize Thai speech and save the audio to a local file.
+
+        Endpoint: ``POST /v3/store/audio/tts`` with a JSON body ``{"text": ...}``.
+        The response audio is written to ``output_path`` (defaults to
+        ``cee.wav`` in the output directory).
+        """
         headers = headers or {}
         data_payload = data_payload or {}
-        request_url = build_url(API_BASE, "v3/store/speech/text-to-speech/cee", {"text": text})
+        body = {"text": text, **data_payload}
 
-        response = request_sync("GET", request_url, apikey=self.apikey, headers=headers,
-                                data={**data_payload})
+        response = request_sync("POST", f"{API_BASE}/v3/store/audio/tts",
+                                apikey=self.apikey,
+                                headers={'Content-Type': 'application/json', **headers},
+                                json_body=body)
         path = build_output_path("cee.wav", output_path)
         with open(path, "wb") as file:
             file.write(response.content)

--- a/packages/iapp-sdk/src/iapp_ai/module_api.py
+++ b/packages/iapp-sdk/src/iapp_ai/module_api.py
@@ -11,12 +11,20 @@ The endpoints, request shapes and return values are unchanged for backward
 compatibility.
 """
 
+import base64
 import json
 import os
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
-from iapp_core import request_sync, open_input_files, build_output_path
+
+from iapp_core import (
+    API_BASE,
+    build_output_path,
+    build_url,
+    open_input_files,
+    request_sync,
+)
 
 
 taskGuid = ""
@@ -30,45 +38,42 @@ class api():
 
     ################## Thai Natural Language Processing ##################
 
-    def thai_qa_api(self, headers={}, question= {}, document={}):
+    def thai_qa_api(self, headers: Optional[Dict[str, Any]] = None, question: Any = "", document: Any = "") -> requests.Response:
+        headers = headers or {}
         request_data_payload = json.dumps({
             'question': question,
             'document': document})
 
-        return request_sync("POST", "https://api.iapp.co.th/thai-qa/inference",
+        return request_sync("POST", f"{API_BASE}/thai-qa",
                             apikey=self.apikey,
                             headers={'Content-Type': 'application/json', **headers},
                             data=request_data_payload)
 
-    def thai_qgen_api(self, text={}, headers={}, data_payload={}):
-        url = "http://api.iapp.co.th/qa-generator-th?text=" + str(text) + "&apikey=" + str(self.apikey)
+    def thai_qgen_api(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        url = build_url(API_BASE, "v3/store/nlp/question/generation", {"text": str(text)})
 
         return request_sync("GET", url, apikey=self.apikey, headers=headers,
                             data={**data_payload})
 
-    def thai_text_summarization(self, text={}, output_length={}, headers={}, data_payload={}):
-        url = "https://api.iapp.co.th/text-summarization?text=" + str(text) + "&output_length=" + str(output_length)
+    def thai_text_summarization(self, text: str = "", output_length: Any = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        url = build_url(API_BASE, "v3/store/nlp/thai-text-summary",
+                        {"text": str(text), "output_length": str(output_length)})
 
-        return request_sync("GET", url, apikey=self.apikey, headers=headers,
+        return request_sync("POST", url, apikey=self.apikey, headers=headers,
                             data={**data_payload})
 
-    def eng_thai_translate(self, text={}, headers={}, data_payload={}):
-        url = "https://api.iapp.co.th/translate/auto?text="+text
+    def eng_thai_translate(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        url = build_url(API_BASE, "v1/text/translate", {"text": text})
 
-        return request_sync("GET", url, apikey=self.apikey, headers=headers,
+        return request_sync("POST", url, apikey=self.apikey, headers=headers,
                             data={**data_payload})
 
-    # #TODO: Will be Fixed
-    # def thai_text_parser(self, text={}, headers={}, data_payload={}):
-    #     request_headers = {"apikey":self.apikey, 'Content-Type': 'application/json', **headers}
-    #     request_data_payload = {**data_payload}
-
-    #     url = "https://api.iapp.co.th/text-thai-parser/parse/"+text
-
-    #     response = requests.request("GET", url, headers=request_headers, data=request_data_payload)
-
-    #     print(json.loads(response.text))
-    #     return response
 
 
 
@@ -171,16 +176,21 @@ class api():
                                 apikey=self.apikey, headers=headers,
                                 data={**data_payload}, files=request_files)
 
-    def license_plate_ocr(self, file_path, headers={}, data_payload={}, files=[]):
+    def license_plate_ocr(self, file_path: str, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, files: Optional[List[Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        files = files or []
         filename = os.path.basename(file_path)
-        request_files = [('file',(filename, open(file_path,'rb'),'image/jpg'))]
-        request_files.extend(files)
+        with open_input_files([file_path]) as (file_obj,):
+            request_files = [('file',(filename, file_obj, 'image/jpg'))]
+            request_files.extend(files)
 
-        return request_sync("POST", "https://api.iapp.co.th/license-plate-recognition/file",
-                            apikey=self.apikey, headers=headers,
-                            data={**data_payload}, files=request_files)
+            return request_sync("POST", "https://api.iapp.co.th/license-plate-recognition/file",
+                                apikey=self.apikey, headers=headers,
+                                data={**data_payload}, files=request_files)
 
-    def license_plate_base64(self, headers={}, data_payload={}):
+    def license_plate_base64(self, headers: Optional[Dict[str, Any]] = None, data_payload: Any = None) -> requests.Response:
+        headers = headers or {}
         request_data_payload = json.dumps({
             'image': data_payload})
 
@@ -432,29 +442,33 @@ class api():
     #     response = requests.request("POST", "https://api.iapp.co.th/signature-detection/file", headers=request_headers, data=request_data_payload, files=request_files)
     #     return response
 
-    def power_meter(self, headers={}, image= {}):
-        request_files = open(image,'r')
-        data = request_files.read()
-        #close file
-        request_files.close()
+    def power_meter(self, headers: Optional[Dict[str, Any]] = None, image: str = "") -> requests.Response:
+        headers = headers or {}
+        with open_input_files([image]) as (image_file,):
+            data = base64.b64encode(image_file.read()).decode("ascii")
         request_data_payload = json.dumps({
             'image': data})
 
-        return request_sync("POST", "https://titipakorn.xyz/ocr/api/predict/ocr_detect/",
+        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/file",
                             apikey=self.apikey, headers=headers,
                             data=request_data_payload)
 
 
-    def water_meter_binary(self, file_path, headers={}, data_payload={}, files=[]):
+    def water_meter_binary(self, file_path: str, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, files: Optional[List[Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        files = files or []
         filename = os.path.basename(file_path)
-        request_files = [('file',(filename, open(file_path,'rb'),'image/jpg'))]
-        request_files.extend(files)
+        with open_input_files([file_path]) as (file_obj,):
+            request_files = [('file',(filename, file_obj, 'image/jpg'))]
+            request_files.extend(files)
 
-        return request_sync("POST", "https://api.iapp.co.th/meter-number-ocr/file",
-                            apikey=self.apikey, headers=headers,
-                            data={**data_payload}, files=request_files)
+            return request_sync("POST", "https://api.iapp.co.th/meter-number-ocr/file",
+                                apikey=self.apikey, headers=headers,
+                                data={**data_payload}, files=request_files)
 
-    def water_meter_base64(self, headers={}, data_payload={}):
+    def water_meter_base64(self, headers: Optional[Dict[str, Any]] = None, data_payload: Any = None) -> requests.Response:
+        headers = headers or {}
         request_data_payload = json.dumps({
             'image': data_payload})
 
@@ -1085,28 +1099,38 @@ class api():
 
     ################## Voice and Speech ##################
 
-    def thai_asr_api(self, file_path, headers={}, data_payload={}, files=[]):
-        request_files = [('file',(file_path, open(file_path,'rb'),'audio/mpga'))]
-        request_files.extend(files)
+    def thai_asr_api(self, file_path: str, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, files: Optional[List[Any]] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        files = files or []
+        with open_input_files([file_path]) as (file_obj,):
+            request_files = [('file',(file_path, file_obj, 'audio/mpga'))]
+            request_files.extend(files)
 
-        return request_sync("POST", "https://api.iapp.co.th/asr",
-                            apikey=self.apikey, headers=headers,
-                            data={**data_payload}, files=request_files)
+            return request_sync("POST", "https://api.iapp.co.th/asr",
+                                apikey=self.apikey, headers=headers,
+                                data={**data_payload}, files=request_files)
 
-    def thai_thaitts_kaitom(self, text={}, headers={}, data_payload={} ):
-        request_url = "https://api.iapp.co.th/thai-tts-kaitom/tts?text=" + text
+    def thai_thaitts_kaitom(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, output_path: Optional[str] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        request_url = build_url(API_BASE, "v3/store/speech/text-to-speech/kaitom", {"text": text})
 
-        response = request_sync("GET", request_url, apikey=self.apikey, headers=headers,
+        response = request_sync("POST", request_url, apikey=self.apikey, headers=headers,
                                 data={**data_payload})
-        with open("media/kaitom.wav", "wb") as file:
+        path = build_output_path("kaitom.wav", output_path)
+        with open(path, "wb") as file:
             file.write(response.content)
         return response
 
-    def thai_thaitts_cee(self, text={}, headers={}, data_payload={} ):
-        request_url = "https://api.iapp.co.th/thai-tts-cee/tts?text=" + text
+    def thai_thaitts_cee(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, output_path: Optional[str] = None) -> requests.Response:
+        headers = headers or {}
+        data_payload = data_payload or {}
+        request_url = build_url(API_BASE, "v3/store/speech/text-to-speech/cee", {"text": text})
 
         response = request_sync("GET", request_url, apikey=self.apikey, headers=headers,
                                 data={**data_payload})
-        with open("media/cee.wav", "wb") as file:
+        path = build_output_path("cee.wav", output_path)
+        with open(path, "wb") as file:
             file.write(response.content)
         return response

--- a/packages/iapp-sdk/tests/test_compat.py
+++ b/packages/iapp-sdk/tests/test_compat.py
@@ -136,14 +136,17 @@ def test_asr_uses_v3_base_path_filename_and_mpga(captured, tmp_path):
 
 
 def test_power_meter_uses_official_endpoint(captured, tmp_path):
-    # D-02: official iApp host (no private titipakorn.xyz). D-03: image is read in
-    # binary and base64-encoded into the JSON body (round-trips).
+    # Official iApp host (no private titipakorn.xyz); the image is read in binary
+    # and base64-encoded into the JSON body (round-trips). Because it sends a
+    # base64 JSON body, it must hit the /base64 variant (the /file variant is
+    # multipart per the docs).
     raw = b"\xff\xd8\xff\x00meter"
     f = tmp_path / "m.jpg"
     f.write_bytes(raw)
     api("K").power_meter(image=str(f))
-    assert captured["url"] == "https://api.iapp.co.th/v3/store/smart-city/power-meter-and-water-meter/file"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/smart-city/power-meter-and-water-meter/base64"
     assert "titipakorn" not in captured["url"]
+    assert captured["headers"].get("Content-Type") == "application/json"
     assert base64.b64decode(json.loads(captured["data"])["image"]) == raw
 
 

--- a/packages/iapp-sdk/tests/test_compat.py
+++ b/packages/iapp-sdk/tests/test_compat.py
@@ -78,16 +78,16 @@ def test_returns_raw_response_and_does_not_raise(captured):
     assert isinstance(resp, requests.Response)
     assert resp.status_code == 403  # 4xx is RETURNED, never raised
     assert captured["apikey"] == "MY_KEY"
-    # D-14: translate is repointed to the MCP path and uses POST.
+    # Translation is a POST with a JSON body (no query string).
     assert captured["method"] == "POST"
-    assert captured["url"] == "https://api.iapp.co.th/v1/text/translate?text=hello"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/nlp/multilingual-translation"
+    assert captured["json_body"] == {"text": "hello", "source_lang": "en", "target_lang": "th"}
     assert captured["raise_for_error"] is False
 
 
 def test_json_endpoint_sets_content_type(captured):
     client = api("K")
     client.thai_qa_api(question="q", document="d")
-    # D-14: thai_qa repointed to the MCP path /thai-qa.
     assert captured["url"] == "https://api.iapp.co.th/thai-qa"
     assert captured["headers"].get("Content-Type") == "application/json"
     assert json.loads(captured["data"]) == {"question": "q", "document": "d"}
@@ -111,18 +111,6 @@ def test_photocopied_url_is_trimmed(captured, tmp_path):
     assert captured["url"] == "https://api.iapp.co.th/thai-national-id-card-with-signature/front"
 
 
-def test_qgen_uses_https_encoded_no_apikey(captured):
-    # D-04/D-05/D-06 + D-14: https, Thai percent-encoded, apikey NOT in the URL
-    # (sent via header by request_sync), repointed to the MCP generation path.
-    api("SECRET").thai_qgen_api("คำถาม & test")
-    url = captured["url"]
-    assert url.startswith("https://api.iapp.co.th/v3/store/nlp/question/generation?text=")
-    assert "http://" not in url
-    assert "apikey" not in url and "SECRET" not in url
-    assert "คำถาม" not in url                 # Thai is percent-encoded, not raw
-    assert captured["apikey"] == "SECRET"      # still delivered to request_sync -> header
-
-
 def test_face_verification_two_files_octet_stream(captured, tmp_path):
     f1 = tmp_path / "a.jpg"
     f1.write_bytes(b"a")
@@ -137,13 +125,13 @@ def test_face_verification_two_files_octet_stream(captured, tmp_path):
     assert all(item[1][2] == "application/octet-stream" for item in captured["files"])
 
 
-def test_asr_uses_raw_path_filename_and_mpga(captured, tmp_path):
+def test_asr_uses_v3_base_path_filename_and_mpga(captured, tmp_path):
     f = tmp_path / "speech.mp3"
     f.write_bytes(b"x")
     api("K").thai_asr_api(str(f))
-    assert captured["url"] == "https://api.iapp.co.th/asr"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/speech/speech-to-text/base"
     _field, filetuple = captured["files"][0]
-    assert filetuple[0] == str(f)        # raw path used as filename (legacy quirk)
+    assert filetuple[0] == str(f)        # raw path used as filename (legacy quirk preserved)
     assert filetuple[2] == "audio/mpga"
 
 
@@ -166,3 +154,131 @@ def test_passport_ocr_uses_two_tuple_file(captured, tmp_path):
     assert captured["url"] == "https://api.iapp.co.th/passport-ocr/ocr"
     # passport uses a 2-tuple (no content type) — must not gain one
     assert len(captured["files"][0][1]) == 2
+
+
+# =========================================================================== #
+# NLP / Speech endpoint contract tests.
+#
+# These lock down the request shape (method, URL, JSON body, Content-Type and
+# multipart fields) of every NLP/Speech method against the iApp AI API. They
+# reuse the `captured` fixture above (which returns a fake response with the
+# body b'{"ok": false}'), so the TTS tests assert that body is what gets written
+# to the output file.
+#
+# Endpoints under test:
+#   * eng_thai_translate      -> POST /v3/store/nlp/multilingual-translation  (JSON)
+#   * thai_text_summarization -> POST /v3/store/nlp/thai-text-summary         (JSON)
+#   * thai_qa_api             -> POST /thai-qa                                (JSON)
+#   * thai_qgen_api           -> GET  /v3/store/nlp/question/generation       (query)
+#   * thai_thaitts_kaitom     -> POST /v3/store/audio/tts                     (JSON)
+#   * thai_thaitts_cee        -> POST /v3/store/audio/tts                     (JSON)
+#   * thai_asr_api            -> POST /v3/store/speech/speech-to-text/base    (multipart)
+# =========================================================================== #
+
+
+# --- eng_thai_translate -> POST /v3/store/nlp/multilingual-translation ------ #
+def test_translate_posts_json_to_multilingual_endpoint(captured):
+    api("K").eng_thai_translate("hello")
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/nlp/multilingual-translation"
+    # Required fields present; defaults keep the original eng->thai direction.
+    assert captured["json_body"] == {"text": "hello", "source_lang": "en", "target_lang": "th"}
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["files"] is None  # JSON body, not multipart/query
+
+
+def test_translate_passes_source_target_and_max_length(captured):
+    api("K").eng_thai_translate("สวัสดี", source_lang="th", target_lang="ja", max_length=128)
+    assert captured["json_body"] == {
+        "text": "สวัสดี",
+        "source_lang": "th",
+        "target_lang": "ja",
+        "max_length": 128,
+    }
+
+
+# --- thai_text_summarization -> POST /v3/store/nlp/thai-text-summary -------- #
+def test_summarization_posts_json_to_summary_endpoint(captured):
+    api("K").thai_text_summarization("ข้อความยาว ๆ")
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/nlp/thai-text-summary"
+    # With no options, only the required `text` field is sent as a JSON body.
+    assert captured["json_body"] == {"text": "ข้อความยาว ๆ"}
+    assert "output_length" not in captured["json_body"]
+    assert captured["headers"]["Content-Type"] == "application/json"
+
+
+def test_summarization_includes_optional_fields_only_when_set(captured):
+    api("K").thai_text_summarization(
+        "text", style="friendly", language="en", max_output_tokens=256
+    )
+    assert captured["json_body"] == {
+        "text": "text",
+        "style": "friendly",
+        "language": "en",
+        "max_output_tokens": 256,
+    }
+
+
+# --- thai_qa_api -> POST /thai-qa (already docs-aligned, guarded here) ------- #
+def test_qa_posts_json_to_thai_qa(captured):
+    api("K").thai_qa_api(question="ใครเป็นนายก", document="บริบท")
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/thai-qa"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert json.loads(captured["data"]) == {"question": "ใครเป็นนายก", "document": "บริบท"}
+
+
+# --- thai_qgen_api -> GET /v3/store/nlp/question/generation?text= ----------- #
+def test_qgen_uses_get_with_query_param(captured):
+    # Question generation is a GET endpoint: the text rides the query string
+    # (https, percent-encoded) and the apikey is sent via header, so neither the
+    # key nor raw Thai leaks into the URL.
+    api("SECRET").thai_qgen_api("ประเทศไทย & test")
+    url = captured["url"]
+    assert captured["method"] == "GET"
+    assert url.startswith("https://api.iapp.co.th/v3/store/nlp/question/generation?text=")
+    assert "http://" not in url
+    assert "ประเทศไทย" not in url                # Thai is percent-encoded, not raw
+    assert "apikey" not in url and "SECRET" not in url
+    assert captured["apikey"] == "SECRET"       # still delivered via header
+
+
+# --- thai_thaitts_kaitom / thai_thaitts_cee -> POST /v3/store/audio/tts ----- #
+def test_tts_kaitom_posts_json_to_v3_tts(captured, tmp_path):
+    out = tmp_path / "kaitom.wav"
+    api("K").thai_thaitts_kaitom("สวัสดีครับ", output_path=str(out))
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/audio/tts"
+    assert captured["json_body"] == {"text": "สวัสดีครับ"}
+    assert captured["headers"]["Content-Type"] == "application/json"
+    # The raw response bytes are written to the requested output path.
+    assert out.read_bytes() == b'{"ok": false}'
+
+
+def test_tts_cee_shares_the_v3_tts_endpoint(captured, tmp_path):
+    out = tmp_path / "cee.wav"
+    api("K").thai_thaitts_cee("ทดสอบ", output_path=str(out))
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/audio/tts"
+    assert captured["json_body"] == {"text": "ทดสอบ"}
+    assert out.read_bytes() == b'{"ok": false}'
+
+
+# --- thai_asr_api -> POST /v3/store/speech/speech-to-text/base (multipart) -- #
+def test_asr_posts_multipart_to_v3_base(captured, tmp_path):
+    f = tmp_path / "speech.mp3"
+    f.write_bytes(b"\x00\x01")
+    api("K").thai_asr_api(str(f))
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/speech/speech-to-text/base"
+    field, filetuple = captured["files"][0]
+    assert field == "file"               # audio is uploaded under the "file" field
+    assert filetuple[2] == "audio/mpga"
+
+
+def test_asr_forwards_extra_form_fields(captured, tmp_path):
+    f = tmp_path / "speech.mp3"
+    f.write_bytes(b"\x00")
+    api("K").thai_asr_api(str(f), data_payload={"chunk_size": "7", "use_asr_pro": "0"})
+    assert captured["data"] == {"chunk_size": "7", "use_asr_pro": "0"}

--- a/packages/iapp-sdk/tests/test_compat.py
+++ b/packages/iapp-sdk/tests/test_compat.py
@@ -10,6 +10,7 @@ and no API key. They lock down the behaviors existing users depend on:
 * multipart file tuples keep their exact field names and content types.
 """
 
+import base64
 import json
 
 import pytest
@@ -77,15 +78,17 @@ def test_returns_raw_response_and_does_not_raise(captured):
     assert isinstance(resp, requests.Response)
     assert resp.status_code == 403  # 4xx is RETURNED, never raised
     assert captured["apikey"] == "MY_KEY"
-    assert captured["method"] == "GET"
-    assert captured["url"] == "https://api.iapp.co.th/translate/auto?text=hello"
+    # D-14: translate is repointed to the MCP path and uses POST.
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/v1/text/translate?text=hello"
     assert captured["raise_for_error"] is False
 
 
 def test_json_endpoint_sets_content_type(captured):
     client = api("K")
     client.thai_qa_api(question="q", document="d")
-    assert captured["url"] == "https://api.iapp.co.th/thai-qa/inference"
+    # D-14: thai_qa repointed to the MCP path /thai-qa.
+    assert captured["url"] == "https://api.iapp.co.th/thai-qa"
     assert captured["headers"].get("Content-Type") == "application/json"
     assert json.loads(captured["data"]) == {"question": "q", "document": "d"}
 
@@ -108,10 +111,16 @@ def test_photocopied_url_is_trimmed(captured, tmp_path):
     assert captured["url"] == "https://api.iapp.co.th/thai-national-id-card-with-signature/front"
 
 
-def test_qgen_uses_plain_http_and_apikey_in_query(captured):
-    api("SECRET").thai_qgen_api("text")
-    assert captured["url"].startswith("http://api.iapp.co.th/qa-generator-th?text=")
-    assert "&apikey=SECRET" in captured["url"]
+def test_qgen_uses_https_encoded_no_apikey(captured):
+    # D-04/D-05/D-06 + D-14: https, Thai percent-encoded, apikey NOT in the URL
+    # (sent via header by request_sync), repointed to the MCP generation path.
+    api("SECRET").thai_qgen_api("คำถาม & test")
+    url = captured["url"]
+    assert url.startswith("https://api.iapp.co.th/v3/store/nlp/question/generation?text=")
+    assert "http://" not in url
+    assert "apikey" not in url and "SECRET" not in url
+    assert "คำถาม" not in url                 # Thai is percent-encoded, not raw
+    assert captured["apikey"] == "SECRET"      # still delivered to request_sync -> header
 
 
 def test_face_verification_two_files_octet_stream(captured, tmp_path):
@@ -138,11 +147,16 @@ def test_asr_uses_raw_path_filename_and_mpga(captured, tmp_path):
     assert filetuple[2] == "audio/mpga"
 
 
-def test_power_meter_hits_legacy_host(captured, tmp_path):
-    f = tmp_path / "m.txt"
-    f.write_text("base64data")
+def test_power_meter_uses_official_endpoint(captured, tmp_path):
+    # D-02: official iApp host (no private titipakorn.xyz). D-03: image is read in
+    # binary and base64-encoded into the JSON body (round-trips).
+    raw = b"\xff\xd8\xff\x00meter"
+    f = tmp_path / "m.jpg"
+    f.write_bytes(raw)
     api("K").power_meter(image=str(f))
-    assert captured["url"] == "https://titipakorn.xyz/ocr/api/predict/ocr_detect/"
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/smart-city/power-meter-and-water-meter/file"
+    assert "titipakorn" not in captured["url"]
+    assert base64.b64decode(json.loads(captured["data"])["image"]) == raw
 
 
 def test_passport_ocr_uses_two_tuple_file(captured, tmp_path):

--- a/packages/iapp-sdk/tests/test_compat.py
+++ b/packages/iapp-sdk/tests/test_compat.py
@@ -285,3 +285,49 @@ def test_asr_forwards_extra_form_fields(captured, tmp_path):
     f.write_bytes(b"\x00")
     api("K").thai_asr_api(str(f), data_payload={"chunk_size": "7", "use_asr_pro": "0"})
     assert captured["data"] == {"chunk_size": "7", "use_asr_pro": "0"}
+
+
+# =========================================================================== #
+# Smart-city OCR endpoint contract tests (water meter / license plate).
+# Each method has a file (multipart) and a base64 (JSON) variant.
+# =========================================================================== #
+
+
+def test_water_meter_binary_uploads_file_multipart(captured, tmp_path):
+    f = tmp_path / "meter.jpg"
+    f.write_bytes(b"\xff\xd8\xff")
+    api("K").water_meter_binary(str(f))
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/meter-number-ocr/file"
+    field, filetuple = captured["files"][0]
+    assert field == "file"
+    assert filetuple[0] == "meter.jpg"   # basename used as filename
+    assert filetuple[2] == "image/jpg"
+
+
+def test_water_meter_base64_sends_json_image(captured):
+    api("K").water_meter_base64(data_payload="BASE64DATA")
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/meter-number-ocr/base64"
+    assert captured["headers"].get("Content-Type") == "application/json"
+    assert json.loads(captured["data"]) == {"image": "BASE64DATA"}
+
+
+def test_license_plate_ocr_uploads_file_multipart(captured, tmp_path):
+    f = tmp_path / "car.jpg"
+    f.write_bytes(b"\xff\xd8\xff")
+    api("K").license_plate_ocr(str(f))
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/license-plate-recognition/file"
+    field, filetuple = captured["files"][0]
+    assert field == "file"
+    assert filetuple[0] == "car.jpg"     # basename used as filename
+    assert filetuple[2] == "image/jpg"
+
+
+def test_license_plate_base64_sends_json_image(captured):
+    api("K").license_plate_base64(data_payload="BASE64DATA")
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.iapp.co.th/iapp_license_plate_recognition_v1_base64"
+    assert captured["headers"].get("Content-Type") == "application/json"
+    assert json.loads(captured["data"]) == {"image": "BASE64DATA"}

--- a/packages/iapp-sdk/tests/test_live_smoke.py
+++ b/packages/iapp-sdk/tests/test_live_smoke.py
@@ -1,28 +1,115 @@
-"""Live integration smoke tests (no media fixtures required).
+"""Live integration smoke tests for the docs-aligned NLP/Speech endpoints.
 
 These hit the real ``api.iapp.co.th`` and require a valid ``IAPP_API_KEY``. They
-are skipped automatically when the key is unset (see ``conftest.py``). They use
-only text inputs, so no image/audio fixtures are needed — they exist to confirm
-the SDK still talks to the live API end to end and returns a ``requests.Response``.
+are skipped automatically when the key is unset (see ``conftest.py``).
+
+The text-only NLP tests (translate, summarize, QA, question generation) need no
+media fixtures. The TTS tests synthesize audio and just assert a non-empty
+response is written to disk. The ASR test prefers a real audio file via
+``IAPP_TEST_AUDIO``, but falls back to a synthetic valid WAV it generates on the
+fly (16 kHz mono PCM16 with a soft tone) so the endpoint can still be smoke-
+tested without hunting for a sample — the transcript may be empty, but a 200
+confirms the SDK reaches the live ASR endpoint correctly.
+
+They exist to confirm the SDK still talks to the live API end to end after the
+endpoints were repointed to match the live API.
 """
 
+import math
 import os
+import struct
+import wave
 
 import requests
 
 from iapp_ai import api
 
 KEY = os.environ.get("IAPP_API_KEY", "")
+AUDIO = os.environ.get("IAPP_TEST_AUDIO", "")
+
+THAI_TEXT = (
+    "ประเทศไทยมีวัฒนธรรมและประวัติศาสตร์อันยาวนาน "
+    "และมีสถานที่ท่องเที่ยวที่มีชื่อเสียงมากมายทั่วทุกภูมิภาค"
+)
+
+
+def _make_wav(path, seconds=2.0, rate=16000, freq=220.0, amplitude=0.2):
+    """Write a valid mono 16-bit PCM WAV with a soft sine tone (stdlib only).
+
+    Not speech, so the transcript is typically empty — but it is a real,
+    decodable audio file, which is enough to smoke-test that the ASR endpoint
+    accepts the upload and returns 200.
+    """
+    n_frames = int(seconds * rate)
+    peak = int(amplitude * 32767)
+    frames = bytearray()
+    for i in range(n_frames):
+        sample = int(peak * math.sin(2 * math.pi * freq * (i / rate)))
+        frames += struct.pack("<h", sample)
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(rate)
+        wav.writeframes(bytes(frames))
+    return str(path)
+
+
+# =========================================================================== #
+# Live smoke checks for the NLP / Speech endpoints. Each confirms the SDK
+# reaches the live API and gets a 200 back.
+#   * eng_thai_translate      -> POST /v3/store/nlp/multilingual-translation
+#   * thai_text_summarization -> POST /v3/store/nlp/thai-text-summary
+#   * thai_qa_api             -> POST /thai-qa
+#   * thai_qgen_api           -> GET  /v3/store/nlp/question/generation?text=
+#   * thai_thaitts_kaitom     -> POST /v3/store/audio/tts
+#   * thai_asr_api            -> POST /v3/store/speech/speech-to-text/base
+# =========================================================================== #
 
 
 def test_translate_live():
-    resp = api(KEY).eng_thai_translate("hello")
+    # POST /v3/store/nlp/multilingual-translation
+    resp = api(KEY).eng_thai_translate("hello", source_lang="en", target_lang="th")
     assert isinstance(resp, requests.Response)
     assert resp.status_code == 200, resp.text
 
 
 def test_summarization_live():
-    text = "ประเทศไทยมีวัฒนธรรมและประวัติศาสตร์อันยาวนานและมีสถานที่ท่องเที่ยวมากมาย"
-    resp = api(KEY).thai_text_summarization(text, 1)
+    # POST /v3/store/nlp/thai-text-summary
+    resp = api(KEY).thai_text_summarization(THAI_TEXT, style="standard", language="th")
+    assert isinstance(resp, requests.Response)
+    assert resp.status_code == 200, resp.text
+
+
+def test_qa_live():
+    # POST /thai-qa
+    resp = api(KEY).thai_qa_api(
+        question="เมืองหลวงของประเทศไทยคือที่ไหน",
+        document="กรุงเทพมหานครเป็นเมืองหลวงของประเทศไทย",
+    )
+    assert isinstance(resp, requests.Response)
+    assert resp.status_code == 200, resp.text
+
+
+def test_question_generation_live():
+    # GET /v3/store/nlp/question/generation?text=
+    resp = api(KEY).thai_qgen_api(THAI_TEXT)
+    assert isinstance(resp, requests.Response)
+    assert resp.status_code == 200, resp.text
+
+
+def test_tts_kaitom_live(tmp_path):
+    # POST /v3/store/audio/tts
+    out = tmp_path / "kaitom.wav"
+    resp = api(KEY).thai_thaitts_kaitom("สวัสดีครับ ทดสอบเสียง", output_path=str(out))
+    assert isinstance(resp, requests.Response)
+    assert resp.status_code == 200, resp.text
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_asr_live(tmp_path):
+    # POST /v3/store/speech/speech-to-text/base
+    # Prefer a real recording if provided, else generate a valid WAV on the fly.
+    audio = AUDIO if (AUDIO and os.path.exists(AUDIO)) else _make_wav(tmp_path / "tone.wav")
+    resp = api(KEY).thai_asr_api(audio)
     assert isinstance(resp, requests.Response)
     assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Repoint the NLP/Speech SDK methods to the endpoints the live iApp API actually serves (verified with live tests), fix the smart-city power_meter variant, and add offline contract tests.

### Endpoint changes
- eng_thai_translate -> POST /v3/store/nlp/multilingual-translation (JSON; adds source_lang/target_lang/max_length)
- thai_text_summarization -> POST /v3/store/nlp/thai-text-summary (JSON; drops non-spec output_length)
- thai_qgen_api -> GET /v3/store/nlp/question/generation
- thai_thaitts_kaitom/cee -> POST /v3/store/audio/tts (JSON)
- thai_asr_api -> POST /v3/store/speech/speech-to-text/base
- power_meter -> POST /v3/store/smart-city/power-meter-and-water-meter/base64 (base64 JSON)

### Tests
- Updated test_compat.py offline assertions and rewrote test_live_smoke.py (ASR live test generates a valid WAV when no sample is provided)
- Added offline contract tests for the 4 smart-city OCR methods (water_meter_binary/base64, license_plate_ocr/base64)
- Offline suite: 77 passed, 6 skipped

### Notes
Three docs pages were found to be inaccurate vs the live API (404/405); endpoints follow the verified live behaviour.

Generated with Claude Code