### PR TITLE
SDK: add face_id_card_verification (eKYC selfie vs ID-card face)

### DIFF
--- a/packages/iapp-sdk/src/iapp_ai/module_api.py
+++ b/packages/iapp-sdk/src/iapp_ai/module_api.py
@@ -570,6 +570,47 @@ class api():
                                 apikey=self.apikey, headers=headers,
                                 data=request_data_payload, files=request_files)
 
+    def face_id_card_verification(
+        self,
+        id_card_path: str,
+        selfie_path: str,
+        headers: Optional[Dict[str, str]] = None,
+        data_payload: Optional[Dict[str, Any]] = None,
+        files: Optional[List[Any]] = None,
+    ) -> requests.Response:
+        """Verify that a selfie matches the face photo on a Thai national ID card.
+
+        The core eKYC identity check: compares a selfie against the face on an ID
+        card and returns per-image and total confidence plus ``isSamePerson``
+        verdicts. Unlike :meth:`face_verification` (face-to-face 1:1), this pairs a
+        selfie with the photo extracted from the ID card.
+
+        Args:
+            id_card_path: Path to the ID card image (JPG/PNG, min 600x400, max 10MB).
+            selfie_path: Path to the selfie image (same constraints).
+            headers: Additional HTTP headers to send with the request.
+            data_payload: Additional form-data parameters to send.
+            files: Additional files to upload.
+
+        Returns:
+            requests.Response: The HTTP response from the API server.
+        """
+        if headers is None:
+            headers = {}
+        if data_payload is None:
+            data_payload = {}
+        if files is None:
+            files = []
+        filename0 = os.path.basename(id_card_path)
+        filename1 = os.path.basename(selfie_path)
+        with open_input_files([id_card_path, selfie_path]) as [fh0, fh1]:
+            request_files = [('file0',(filename0, fh0,'application/octet-stream')),('file1',(filename1, fh1,'application/octet-stream'))]
+            request_files.extend(files)
+
+            return request_sync("POST", "https://api.iapp.co.th/v3/store/ekyc/face-and-id-card-verification",
+                                apikey=self.apikey, headers=headers,
+                                data={**data_payload}, files=request_files)
+
     def _face_config_score(self, data_payload, headers=None):
         if headers is None:
             headers = {}

--- a/packages/iapp-sdk/tests/test_compat.py
+++ b/packages/iapp-sdk/tests/test_compat.py
@@ -125,6 +125,18 @@ def test_face_verification_two_files_octet_stream(captured, tmp_path):
     assert all(item[1][2] == "application/octet-stream" for item in captured["files"])
 
 
+def test_face_id_card_verification_uses_file0_file1(captured, tmp_path):
+    idc = tmp_path / "idcard.jpg"
+    idc.write_bytes(b"idcard")
+    selfie = tmp_path / "selfie.jpg"
+    selfie.write_bytes(b"selfie")
+    api("K").face_id_card_verification(str(idc), str(selfie))
+    assert captured["url"] == "https://api.iapp.co.th/v3/store/ekyc/face-and-id-card-verification"
+    fields = [item[0] for item in captured["files"]]
+    assert fields == ["file0", "file1"]  # file0=id card, file1=selfie
+    assert all(item[1][2] == "application/octet-stream" for item in captured["files"])
+
+
 def test_asr_uses_v3_base_path_filename_and_mpga(captured, tmp_path):
     f = tmp_path / "speech.mp3"
     f.write_bytes(b"x")


### PR DESCRIPTION
## Summary
Closes the last eKYC docs-coverage gap. The SDK had `face_verification` (face-to-face 1:1) but **no** selfie-vs-ID-card KYC check — the core eKYC identity flow. MCP already exposes it as `iapp_face_id_card_kyc`.

## Change
New method `face_id_card_verification(id_card_path, selfie_path, ...)`:
- `POST /v3/store/ekyc/face-and-id-card-verification`
- multipart: `file0` = ID card, `file1` = selfie (matches the live endpoint / MCP)
- follows SDK conventions: type hints, `None` default args, `open_input_files` (no leak)
- offline contract test added (asserts endpoint + `file0`/`file1` fields)

## Verification
- Offline: 45 passed, 15 skipped
- ⚠️ Not yet live-verified with real images (needs a real ID card + selfie). Endpoint/fields mirror MCP's working tool.

## eKYC coverage after this
SDK 10/10 ✅ (was 9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)