### PR TITLE
fix: align MCP/SDK endpoints with v3/store docs and fix type checks

### DIFF
--- a/packages/iapp-mcp/src/iapp_mcp/tools/ekyc.py
+++ b/packages/iapp-mcp/src/iapp_mcp/tools/ekyc.py
@@ -391,7 +391,7 @@ async def iapp_face_recognition(
             "POST",
             endpoint_map[action],
             data=data,
-            file_fields=[("file", file_path)] if needs_file else None,
+            file_fields=[("file", file_path)] if (needs_file and file_path is not None) else None,
         )
         return format_json_response(response)
     except IAppAPIError as e:

--- a/packages/iapp-mcp/src/iapp_mcp/tools/generation.py
+++ b/packages/iapp-mcp/src/iapp_mcp/tools/generation.py
@@ -1,7 +1,7 @@
 """Image and video generation tools: Nano Banana, background removal, Seedance video."""
 
 import base64
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from ..app import mcp
 from ..client import (
@@ -152,7 +152,7 @@ async def iapp_video_generation_submit(
         Pricing: ~0.14-0.33 IC per 1K output tokens; failed jobs cost 0 IC.
     """
     try:
-        content = [{"type": "text", "text": prompt}]
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
         if first_frame_image_url:
             content.append(
                 {

--- a/packages/iapp-mcp/src/iapp_mcp/tools/llm.py
+++ b/packages/iapp-mcp/src/iapp_mcp/tools/llm.py
@@ -131,7 +131,7 @@ async def iapp_thanoy_legal_qa(query: str) -> str:
     """
     try:
         response = await request(
-            "POST", "/thanoy", json_body={"query": query}
+            "POST", "/v3/store/llm/thanoy-legal-ai", json_body={"query": query}
         )
         return format_json_response(response)
     except IAppAPIError as e:

--- a/packages/iapp-mcp/src/iapp_mcp/tools/nlp.py
+++ b/packages/iapp-mcp/src/iapp_mcp/tools/nlp.py
@@ -1,6 +1,6 @@
 """Thai NLP tools: translation, summarization, sentiment, toxicity, QA, question generation."""
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from ..app import mcp
 from ..client import IAppAPIError, format_json_response, request
@@ -43,7 +43,7 @@ async def iapp_translate(
         JSON string with the translation and processing time. Cost: 1 IC per 400 chars.
     """
     try:
-        data = {"text": text, "source_lang": source_lang, "target_lang": target_lang}
+        data: dict[str, Any] = {"text": text, "source_lang": source_lang, "target_lang": target_lang}
         if max_length is not None:
             data["max_length"] = max_length
         response = await request("POST", "/v3/store/nlp/multilingual-translation", json_body=data)
@@ -75,7 +75,7 @@ async def iapp_summarize(
         JSON string with the summary. Cost: 1 IC per 400 chars.
     """
     try:
-        body = {"text": text, "style": style, "language": language}
+        body: dict[str, Any] = {"text": text, "style": style, "language": language}
         if max_output_tokens is not None:
             body["max_output_tokens"] = max_output_tokens
         response = await request("POST", "/v3/store/nlp/thai-text-summary", json_body=body)

--- a/packages/iapp-mcp/src/iapp_mcp/tools/smartcity.py
+++ b/packages/iapp-mcp/src/iapp_mcp/tools/smartcity.py
@@ -1,11 +1,11 @@
 """Smart city and data tools: license plate, meter OCR, route optimization, Thai holidays."""
 
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
 from ..app import mcp
-from ..client import IAppAPIError, format_json_response, request, resolve_input_file
+from ..client import IAppAPIError, format_json_response, request
 
 _READONLY = {
     "readOnlyHint": True,
@@ -53,17 +53,11 @@ async def iapp_meter_ocr(file_path: str) -> str:
     Returns:
         JSON string with the meter reading (label field). Cost: 1 IC.
     """
-    import base64
-
     try:
-        resolved_path = resolve_input_file(file_path)
-        with open(resolved_path, "rb") as f:
-            base64_data = base64.b64encode(f.read()).decode("ascii")
-
         response = await request(
             "POST",
-            "/v3/store/smart-city/power-meter-and-water-meter/base64",
-            json_body={"image": base64_data},
+            "/v3/store/smart-city/power-meter-and-water-meter/file",
+            file_fields=[("file", file_path)],
         )
         return format_json_response(response)
     except IAppAPIError as e:
@@ -161,7 +155,7 @@ async def iapp_thai_holidays(
         JSON string with holiday dates, Thai names, weekdays and types. Cost: 0.1 IC.
     """
     try:
-        params = {"holiday_type": holiday_type}
+        params: dict[str, Any] = {"holiday_type": holiday_type}
         if year is not None:
             response = await request(
                 "GET", f"/v3/store/data/thai-holiday/year/{year}", params=params

--- a/packages/iapp-sdk/src/iapp_ai/module_api.py
+++ b/packages/iapp-sdk/src/iapp_ai/module_api.py
@@ -240,7 +240,7 @@ class api():
         request_data_payload = json.dumps({
             'image': data_payload})
 
-        return request_sync("POST", "https://api.iapp.co.th/iapp_license_plate_recognition_v1_base64",
+        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/license-plate-ocr/base64",
                             apikey=self.apikey,
                             headers={'Content-Type': 'application/json', **headers},
                             data=request_data_payload)
@@ -491,7 +491,7 @@ class api():
     def power_meter(self, headers: Optional[Dict[str, Any]] = None, image: str = "") -> requests.Response:
         """Read the number from a power/water meter image (base64 variant).
 
-        Endpoint: ``POST /v3/store/smart-city/power-meter-and-water-meter/base64``
+        Endpoint: ``POST /v3/store/smart-city/power-meter-and-water-meter``
         with the image base64-encoded in a JSON body ``{"image": ...}``.
         """
         headers = headers or {}
@@ -500,7 +500,7 @@ class api():
         request_data_payload = json.dumps({
             'image': data})
 
-        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/base64",
+        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter",
                             apikey=self.apikey,
                             headers={'Content-Type': 'application/json', **headers},
                             data=request_data_payload)
@@ -508,14 +508,16 @@ class api():
 
     def water_meter_binary(self, file_path: str, headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, files: Optional[List[Any]] = None) -> requests.Response:
         headers = headers or {}
+        data_payload = data_payload or {}
+        files = files or []
+        filename = os.path.basename(file_path)
         with open_input_files([file_path]) as (file_obj,):
-            data = base64.b64encode(file_obj.read()).decode("ascii")
-        request_data_payload = json.dumps({'image': data})
+            request_files = [('file', (filename, file_obj, 'image/jpg'))]
+            request_files.extend(files)
 
-        return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/base64",
-                            apikey=self.apikey,
-                            headers={'Content-Type': 'application/json', **headers},
-                            data=request_data_payload)
+            return request_sync("POST", f"{API_BASE}/v3/store/smart-city/power-meter-and-water-meter/file",
+                                apikey=self.apikey, headers=headers,
+                                data={**data_payload}, files=request_files)
 
     def water_meter_base64(self, headers: Optional[Dict[str, Any]] = None, data_payload: Any = None) -> requests.Response:
         headers = headers or {}
@@ -1240,18 +1242,18 @@ class api():
     def thai_thaitts_cee(self, text: str = "", headers: Optional[Dict[str, Any]] = None, data_payload: Optional[Dict[str, Any]] = None, output_path: Optional[str] = None) -> requests.Response:
         """Synthesize Thai speech and save the audio to a local file.
 
-        Endpoint: ``POST /v3/store/audio/tts`` with a JSON body ``{"text": ...}``.
+        Endpoint: ``GET /v3/store/speech/text-to-speech/cee`` with query params ``text``.
         The response audio is written to ``output_path`` (defaults to
         ``cee.wav`` in the output directory).
         """
         headers = headers or {}
         data_payload = data_payload or {}
-        body = {"text": text, **data_payload}
+        params = {"text": text, **data_payload}
 
-        response = request_sync("POST", f"{API_BASE}/v3/store/audio/tts",
+        response = request_sync("GET", f"{API_BASE}/v3/store/speech/text-to-speech/cee",
                                 apikey=self.apikey,
-                                headers={'Content-Type': 'application/json', **headers},
-                                json_body=body)
+                                headers=headers,
+                                params=params)
         path = build_output_path("cee.wav", output_path)
         with open(path, "wb") as file:
             file.write(response.content)
@@ -1302,7 +1304,7 @@ class api():
         """Thanoy Thai Legal AI chatbot (ทนายAI)."""
         headers = headers or {}
         payload = json.dumps({"query": query})
-        return request_sync("POST", "https://api.iapp.co.th/thanoy", apikey=self.apikey,
+        return request_sync("POST", f"{API_BASE}/v3/store/llm/thanoy-legal-ai", apikey=self.apikey,
                             headers={'Content-Type': 'application/json', **headers},
                             data=payload)
 

--- a/scripts/test_verify_a6.py
+++ b/scripts/test_verify_a6.py
@@ -8,7 +8,6 @@ Ensures that:
 
 import sys
 from pathlib import Path
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import release


### PR DESCRIPTION
SDK:
- license_plate_base64: POST /v3/store/smart-city/license-plate-ocr/base64
- power_meter: POST /v3/store/smart-city/power-meter-and-water-meter
- water_meter_binary: POST /v3/store/smart-city/power-meter-and-water-meter/file
- thai_thaitts_cee (cee voice): GET /v3/store/speech/text-to-speech/cee
- thanoy_legal_qa: POST /v3/store/llm/thanoy-legal-ai

MCP:
- iapp_meter_ocr: POST /v3/store/smart-city/power-meter-and-water-meter/file
- iapp_thanoy_legal_qa: POST /v3/store/llm/thanoy-legal-ai